### PR TITLE
macOS 11 Big Sur

### DIFF
--- a/debloat-google.sh
+++ b/debloat-google.sh
@@ -9,7 +9,7 @@ echo "### by A2L5E0X1          "
 sleep 1
 
 # Check for ADB
-if [ "$(which adb)" != "/usr/bin/adb" ]; then
+if [ "$(which adb)" != "/usr/local/bin/adb" ]; then
     echo "ERROR: ADB not found! Please install it or set correct PATH!" && exit 255
 fi
 

--- a/debloat-huawei.sh
+++ b/debloat-huawei.sh
@@ -9,7 +9,7 @@ echo "### by A2L5E0X1        "
 sleep 1
 
 # Check for ADB
-if [ "$(which adb)" != "/usr/bin/adb" ]; then
+if [ "$(which adb)" != "/usr/local/bin/adb" ]; then
     echo "ERROR: ADB not found! Please install it or set correct PATH!" && exit 255
 fi
 


### PR DESCRIPTION
Was able to degoogle and dehuawei my Honor phone (Running Android 9.0), I just changed the location of the adb path.

So macOS users, that had installed adb using brew on macOS Big Sur just modify line 13 to the following:

I used (brew install android-platform-tools ) to install ADB

`# Check for ADB
if [ "$(which adb)" != "/usr/local/bin/adb" ]; then
 echo "ERROR: ADB not found! Please install it or set correct PATH!" && exit 255
fi
`

